### PR TITLE
Updating library versions and fixing issue with looping

### DIFF
--- a/DocuSign.MyClick/DocuSign.MyClickwrap.COVID19Waiver.UnitTests/DocuSign.MyClickwrap.COVID19Waiver.UnitTests.csproj
+++ b/DocuSign.MyClick/DocuSign.MyClickwrap.COVID19Waiver.UnitTests/DocuSign.MyClickwrap.COVID19Waiver.UnitTests.csproj
@@ -7,17 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.13.0" />
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.13.0" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Moq" Version="4.14.5" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="AutoFixture" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0-preview-20211109-03" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.2-pre.12" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/DocuSign.MyClick/DocuSign.MyClickwrap.COVID19Waiver/ClientApp/src/index.js
+++ b/DocuSign.MyClick/DocuSign.MyClickwrap.COVID19Waiver/ClientApp/src/index.js
@@ -2,10 +2,9 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
-import registerServiceWorker from "./registerServiceWorker";
 import "./i18n";
 import "bootstrap/dist/js/bootstrap.min.js";
-
+import { unregister } from "./registerServiceWorker";
 const baseUrl = document.getElementsByTagName("base")[0].getAttribute("href");
 const rootElement = document.getElementById("root");
 
@@ -16,4 +15,4 @@ ReactDOM.render(
   rootElement
 );
 
-registerServiceWorker();
+unregister();

--- a/DocuSign.MyClick/DocuSign.MyClickwrap.COVID19Waiver/DocuSign.MyClickwrap.COVID19Waiver.csproj
+++ b/DocuSign.MyClick/DocuSign.MyClickwrap.COVID19Waiver/DocuSign.MyClickwrap.COVID19Waiver.csproj
@@ -14,12 +14,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DocuSign.eSign.dll" Version="4.5.2" />
+    <PackageReference Include="DocuSign.eSign.dll" Version="5.8.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.6" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="RestSharp" Version="106.11.4" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.11.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="RestSharp" Version="106.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DocuSign.MyClick/DocuSign.MyClickwrap.NonDisclosureAgreement.UnitTests/DocuSign.MyClickwrap.NonDisclosureAgreement.UnitTests.csproj
+++ b/DocuSign.MyClick/DocuSign.MyClickwrap.NonDisclosureAgreement.UnitTests/DocuSign.MyClickwrap.NonDisclosureAgreement.UnitTests.csproj
@@ -7,17 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.13.0" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Moq" Version="4.14.5" />
-    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0-preview-20211109-03" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.2-pre.12" />
 
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/DocuSign.MyClick/DocuSign.MyClickwrap.NonDisclosureAgreement/DocuSign.MyClickwrap.NonDisclosureAgreement.csproj
+++ b/DocuSign.MyClick/DocuSign.MyClickwrap.NonDisclosureAgreement/DocuSign.MyClickwrap.NonDisclosureAgreement.csproj
@@ -14,11 +14,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DocuSign.eSign.dll" Version="4.5.2" />
+    <PackageReference Include="DocuSign.eSign.dll" Version="5.8.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.6" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.11.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DocuSign.MyClick/DocuSign.MyClickwrap.TermsAndConditions.UnitTests/DocuSign.MyClickwrap.TermsAndConditions.UnitTests.csproj
+++ b/DocuSign.MyClick/DocuSign.MyClickwrap.TermsAndConditions.UnitTests/DocuSign.MyClickwrap.TermsAndConditions.UnitTests.csproj
@@ -9,13 +9,19 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.13.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.13.0" />
-    <PackageReference Include="DocuSign.eSign.dll" Version="4.5.2" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Moq" Version="4.14.5" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="DocuSign.eSign.dll" Version="5.8.0" />
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0-preview-20211109-03" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.2-pre.12" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/DocuSign.MyClick/DocuSign.MyClickwrap.TermsAndConditions/DocuSign.MyClickwrap.TermsAndConditions.csproj
+++ b/DocuSign.MyClick/DocuSign.MyClickwrap.TermsAndConditions/DocuSign.MyClickwrap.TermsAndConditions.csproj
@@ -13,12 +13,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="DocuSign.eSign.dll" Version="4.5.2" />
+		<PackageReference Include="DocuSign.eSign.dll" Version="5.8.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.6" />
 		<PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.1" />
-		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />
-		<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-		<PackageReference Include="RestSharp" Version="106.11.4" />
+		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.11.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="RestSharp" Version="106.13.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/DocuSign.MyClick/DocuSign.MyClickwrap.UI/DocuSign.MyClickwrap.UI.csproj
+++ b/DocuSign.MyClick/DocuSign.MyClickwrap.UI/DocuSign.MyClickwrap.UI.csproj
@@ -14,9 +14,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.11.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated libraries:
AutoFixture: 4.17.0,
AutoFixture.Xunit2: 4.17.0,
FluentAssertions: 6.2.0,
Microsoft.NET.Test.Sdk: 17.1.0-preview-20211109-03,
Moq: 4.16.1,
xunit: 2.4.2-pre.12,
coverlet.collector: 3.1.0,
Microsoft.VisualStudio.Azure.Containers.Tools.Targets: 1.11.1,
Newtonsoft.Json: 13.0.1,
RestSharp: 106.13.0,
xunit.runner.visualstudio: 2.4.3

Internal SDKs:
DocuSign.eSign.dll: 5.8.0

Also, the PR includes a **fix for an issue with infinite looping** (the fix is located in index.js file). 
Please, redeploy the application to the production environment to renew the code version there.

